### PR TITLE
Force user to set their own namespace option and make namespace optio…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,18 +28,37 @@ module.exports = function(grunt) {
       tests: ['tmp']
     },
 
+    /* jshint camelcase: false */
     betajs_templates: {
-      dist: {
+      dest: {
         files: {
           'tmp/expected.js': [
             'test/fixtures/*.html'
-          ]
+          ],
+        },
+        options: {
+          namespace: 'App.Templates'
         }
       },
-      options: {
-        namespace: 'App.Templates'
+      newNamespace: {
+        files: {
+          'tmp/newNamespace.js': [
+            'test/fixtures/*.html'
+          ]
+        },
+        options: {
+          namespace: 'App.NewNamespace'
+        }
+      },
+      noNamespace: {
+        files: {
+          'tmp/noNamespace.js': [
+            'test/fixtures/*.html'
+          ]
+        }
       }
     },
+    /* jshint camelcase: true */
 
     // Unit tests.
     nodeunit: {
@@ -55,10 +74,20 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-continue');
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
-  // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'betajs_templates', 'nodeunit']);
+  // plugin's task(s), then test the result. grunt-continue is used to test
+  // betajs_templates:noNamespace which exits with a failure. Continuing allows
+  // writing tests to ensure the `noNamespace.js` file was not created.
+  grunt.registerTask('test', [
+    'clean',
+    'betajs_templates:dest',
+    'betajs_templates:newNamespace',
+    'continue:on',
+    'betajs_templates:noNamespace',
+    'continue:off',
+    'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ grunt.loadNpmTasks('grunt-betajs-templates');
 ### Overview
 In your project's Gruntfile, add a section named `betajs_templates` to the data object passed into `grunt.initConfig()`.
 
+#### Options
+The namespace of each `betajs_templates` namespace **must** be specified. See
+any of the examples for guidance on specifying the namespace option.
+
 ```js
 grunt.initConfig({
   betajs_templates: {
@@ -32,32 +36,42 @@ grunt.initConfig({
           "src/my_second_template.html",
           "src/my_last_templates.html"
         ]
+      },
+      options: {
+        namespace: 'App.Templates'
       }
     },
   },
 });
 ```
 
-#### Options
-The namespace of the `betajs_templates` can be specified using
-`options.namespace`.
+Naturally, it is possible to specify a different namespace for each subtask.
+Multiple namespaces for different subtasks can be seen in the example below.
 
 ```js
 grunt.initConfig({
   betajs_templates: {
-    options: {
-      namespace: "App.Templates"
-    },
-    dist: {
+    dashboard: {
       files: {
-        "dest/betajs-templates.js": [
-          "src/my_first_template.html",
-          "src/my_second_template.html",
-          "src/my_last_templates.html"
+        "dest/betajs-dashboard-templates.js": [
+          "dashboard/*.html",
         ]
+      },
+      options: {
+        namespace: 'App.Dashboard'
       }
     },
-  },
+    homepage: {
+      files: {
+        "dest/betajs-homepage-templates.js": [
+          "homepage/*.html"
+        ]
+      },
+      options: {
+        namespace: 'App.Homepage'
+      }
+    }
+  }
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.9.2",
+    "grunt": "~0.4.5",
+    "grunt-continue": "^0.1.0",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-nodeunit": "^0.3.3"
   },
   "peerDependencies": {
     "grunt": "~0.4.5"

--- a/tasks/betajs_templates.js
+++ b/tasks/betajs_templates.js
@@ -48,7 +48,13 @@ module.exports = function(grunt) {
       }
     };
 
-    var namespace = this.options({namespace: "BetaJS.Templates.Cached"}).namespace;
+    // Return with error if no namespace is specified.
+    if (!this.options().namespace) {
+      grunt.fail.warn("Please specify options.namespace for this task.");
+      return ""; // Even if force is used, the execution will stop here.
+    }
+
+    var namespace = this.options().namespace;
 
     var scriptRegex = /<script\s+type\s*=\s*["']text\/template["']\s+id\s*=\s*["']([^"']*)["']\s*>([\w\W]*?)<\/script>/ig;
 

--- a/test/betajs_templates_test.js
+++ b/test/betajs_templates_test.js
@@ -1,3 +1,5 @@
+/* jshint camelcase: false */
+
 'use strict';
 
 var grunt = require('grunt');
@@ -7,14 +9,36 @@ exports.betajs_templates = {
     done();
   },
 
-  // test default config
+  // Test a default configuration.
   default: function(test) {
     test.expect(1);
 
     var actual = grunt.file.read('tmp/expected.js');
     var expected = grunt.file.read('test/expected/expected.js');
-    test.equal(actual, expected, 'should describe what the default behavior is.');
+    test.equal(actual, expected, 'Should describe what the default behavior is.');
 
     test.done();
   },
+
+  // Test specifying a separate namespace for a new subtask.
+  newNamespace: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/newNamespace.js');
+    var expected = grunt.file.read('test/expected/newNamespace.js');
+    test.equal(actual, expected, 
+               'Should allow custom specification of a namespace per filegroup.');
+
+    test.done();
+  },
+
+  // Ensure task does not execute if `options.namespace` is not specified.
+  noNamespace: function(test) {
+    test.expect(1);
+
+    test.ok(!grunt.file.exists('tmp/noNamespace.js'),
+            'Should not have created dest file when options.namespace was not specified.');
+
+    test.done();
+  }
 };

--- a/test/expected/newNamespace.js
+++ b/test/expected/newNamespace.js
@@ -1,0 +1,4 @@
+App.NewNamespace = App.NewNamespace || {};
+App.NewNamespace['first'] = '   <h1>Hi everybody</h1> ';
+
+App.NewNamespace['second'] = '   <h1>Bye!</h1> ';


### PR DESCRIPTION
…n individual to each subtask.

Forcing the user to set their own namespace option avoids the difficulty and futility of choosing a default appropriate for a variety of different solutions. 

An individual namespace option for each subtask increases flexibility. Now the user can store compiled BetaJS templates under multiple different namespaces. Given that different apps may wish to use different namespaces for templates, this flexibility is necessary.

Fixes #3, Fixes #1 
